### PR TITLE
Update react-day-picker to v9.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "lucide-react": "^0.462.0",
     "next-themes": "^0.3.0",
     "react": "^18.3.1",
-    "react-day-picker": "^8.10.1",
+    "react-day-picker": "^9.0.0",
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.59.0",
     "react-resizable-panels": "^2.1.3",


### PR DESCRIPTION
Updates react-day-picker dependency from version ^8.10.1 to ^9.0.0.

This is a major version upgrade that may include breaking changes.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/116ba46f629b4b36958a0a2ae08fafaf/neon-studio)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>116ba46f629b4b36958a0a2ae08fafaf</projectId>-->
<!--<branchName>neon-studio</branchName>-->